### PR TITLE
Restricted js-beautify version to 1.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "event-stream": "~3.1.5",
-    "js-beautify": "~1.5.1",
+    "js-beautify": "1.5.1",
     "gulp-util": "~2.2.14",
     "lodash": "~2.4.1",
     "underscore.string": "~2.3.3"


### PR DESCRIPTION
Restricted js-beautify version to 1.5.1 due to incompatibility with 1.5.2.
Related issue: https://github.com/sjkaliski/numbers.js/issues/124
