### PR TITLE
add possibility to disable successfull beautifying

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,7 +73,7 @@ function beautify(file, config, actionHandler) {
       beautifyConfig = setup[1],
       addNewLine = setup[2];
 
-  gutil.log('Beautifying', file.relative);
+  if(config.logSuccess) gutil.log('Beautifying', file.relative);
   var original = file.contents.toString('utf8');
 
   var result = beautifier(original, beautifyConfig);
@@ -122,7 +122,8 @@ module.exports = function prettify(params) {
     mode: 'VERIFY_AND_WRITE',
     js: {},
     css: {},
-    html: {}
+    html: {},
+		logSuccess: true
   });
 
   var config;

--- a/index.js
+++ b/index.js
@@ -123,7 +123,7 @@ module.exports = function prettify(params) {
     js: {},
     css: {},
     html: {},
-		logSuccess: true
+    logSuccess: true
   });
 
   var config;


### PR DESCRIPTION
As I'm using gulp-jsbeautify on many files, I'd like to have an option to disable all the "Beautifying file.extension" messages in console. Defaults to true (you need to opt-in via "logSuccess"-parameter)