### PR TITLE
colorized logs to match gulp convention

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,7 +65,7 @@ function getBeautifierSetup(file, config) {
 function beautify(file, config, actionHandler) {
   var setup = getBeautifierSetup(file, config);
   if (!setup) {
-    gutil.log('Cannot beautify ' + file.relative + ' (only js, css and html files can be beautified)');
+    gutil.log('Cannot beautify', gutil.colors.cyan(file.relative), '(only js, css and html files can be beautified)');
     return;
   }
 
@@ -74,7 +74,7 @@ function beautify(file, config, actionHandler) {
       addNewLine = setup[2];
 
   if (config.logSuccess) {
-    gutil.log('Beautifying', file.relative);
+    gutil.log('Beautifying', gutil.colors.cyan(file.relative));
   }
 
   var original = file.contents.toString('utf8');


### PR DESCRIPTION
minor thing, easy fix. Per the [gulp-util readme](https://github.com/gulpjs/gulp-util#logmsg): 

> The default gulp coloring using gutil.colors.:
> 
>     values (files, module names, etc.) = cyan
>     numbers (times, counts, etc) = magenta
